### PR TITLE
Typo fix + a question

### DIFF
--- a/standalone-translate/standalone-translate.cpp
+++ b/standalone-translate/standalone-translate.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
   mlir::TranslateFromMLIRRegistration withdescription(
       "option", "different from option",
       [](mlir::Operation *op, llvm::raw_ostream &output) {
-        return llvm::LogicalResult::success();
+        return mlir::LogicalResult::success();
       },
       [](mlir::DialectRegistry &a) {});
 


### PR DESCRIPTION
Hi @nullplay,

Here's a small typo fix. I managed to build it and run tests locally.

I wanted to expand Python test a bit by evaluating MLIR string with a `foo` called but for that I need two more imports:
```python
from mlir_standalone.ir import *
from mlir_standalone.dialects import builtin as builtin_d, standalone as standalone_d

from mlir_standalone import passmanager
from mlir_standalone import execution_engine
```

When importing `from mlir_standalone import execution_engine` I get a:
```
ImportError: dlopen(/Users/mateusz/CLionProjects/Finch-mlir/build/python_packages/standalone/mlir_standalone/_mlir_libs/_mlirExecutionEngine.cpython-311-darwin.so, 0x0002): symbol not found in flat namespace (_mlirExecutionEngineCreate)
```
I wonder what I'm missing here. In my local `llvm` build I can import execution_engine with locally built Python bindings. I built my `llvm` repo with:
```
cmake -G Ninja ../llvm \
    -DLLVM_ENABLE_PROJECTS="mlir;llvm;clang;lld" \
    -DLLVM_TARGETS_TO_BUILD="Native" \
    -DCMAKE_BUILD_TYPE=Release \
    -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
    -DPython3_EXECUTABLE="/usr/local/Caskroom/miniconda/base/envs/mlir-python-bindings-dev/bin/python3" \
ninja
```