### PR TITLE
FIX: Add dialects sources

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -43,8 +43,9 @@ add_mlir_python_common_capi_library(FinchPythonCAPI
     # TODO: Remove this in favor of showing fine grained registration once
     # available.
     MLIRPythonExtension.ExecutionEngine
-    MLIRPythonSources.ExecutionEngine
     MLIRPythonExtension.RegisterEverything
+    MLIRPythonSources.ExecutionEngine
+    MLIRPythonSources.Dialects
     MLIRPythonSources.Core
 )
 

--- a/test/python/smoketest.py
+++ b/test/python/smoketest.py
@@ -1,7 +1,13 @@
 # RUN: %python %s | FileCheck %s
 
 from mlir_finch.ir import *
-from mlir_finch.dialects import builtin as builtin_d, finch as finch_d
+from mlir_finch.dialects import (
+    builtin as builtin_d,
+    finch as finch_d,
+    linalg as linalg_d,
+    sparse_tensor as sparse_tensor_d,
+)
+
 
 with Context():
     finch_d.register_dialect()


### PR DESCRIPTION
Hi @nullplay,

In this PR I added some build configuration so that other dialects can be imported and used from `mlir_finch` package.

Also, I tried to run `test8.mlir` with `vecdot` but I couldn't get pass `finch-translate` command:
```sh
bin/finch-opt ../test8.mlir --finch-looplet-sequence --finch-looplet-run --cse --sparse-assembler="direct-out=true" --sparsifier="enable-runtime-library=false parallelization-strategy=any-storage-outer-loop" -o ../test8_opt.mlir
```
produces optimized MLIR but it still contains `finch` ops so the next step:
```sh
bin/finch-translate ../test8_opt.mlir --mlir-to-llvmir -o ../test8_opt.ll
```
fails with:
```
../test8_opt.mlir:325:120: error: `!"finch"<"looplet">` type created with unregistered dialect. If this is intended, please call allowUnregisteredDialects() on the MLIRContext, or use -allow-unregistered-dialect with the MLIR opt tool used
  func.func private @buffer_to_looplet(%arg0: memref<?xindex>, %arg1: memref<?xindex>, %arg2: memref<?xf32>) -> !finch.looplet {
```

Is it possible to run `test8.mlir`? (By which I mean generate an executable to run)